### PR TITLE
Add functionality to list each direct descendant with ls command

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,10 +88,21 @@ class App extends React.Component {
 
   mkdirCommand = (directoriesToMake) => {
     const directDescendants = this.findDirectDescendants();
-    
+
     directoriesToMake.forEach(el => {
       directDescendants[el] = {};
     });
+  }
+
+  lsCommand = (commandArg) => {
+    if (!commandArg) {
+      const directDescendants = Object.keys(this.findDirectDescendants())
+      directDescendants.forEach(descendant => {
+        console.log(descendant);
+      });
+    } else {
+      console.log("this command line doesn't have the capability to run `ls` with an argument!");
+    }
   }
 
   handleNewCommand = (command) => {
@@ -107,7 +118,7 @@ class App extends React.Component {
         this.cdCommand(commandArgs);
         break;
       case 'ls':
-        // console.log(directChildren());
+        this.lsCommand(commandArgs[0]);
         break;
       case 'pwd':
         //code
@@ -117,7 +128,6 @@ class App extends React.Component {
         break;
       case 'mkdir':
         this.mkdirCommand(commandArgs);
-        //code
         break;
       case 'rm':
         //code


### PR DESCRIPTION
This PR:
- adds `ls` command functionality - at this time ONLY if `ls` is run with no argument.
- `lsCommand` currently only prints out each direct descendant of current directory; not rending anything in browser yet