### PR TITLE
Feature/previous output

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -11,7 +11,6 @@ class App extends React.Component {
       directoryStructure: { turing: { classwork: {} }, personal: "" },
       pathToCurrentLocation: [],
       currentCommand: [],
-      // previousOutput: [],
     }
   }
 
@@ -97,19 +96,19 @@ class App extends React.Component {
 
     switch (commandType) {
       case 'cd':
-        this.cdCommand(commandArgs);
+        return this.cdCommand(commandArgs);
         break;
       case 'ls':
-        this.lsCommand(commandArgs[0]);
+        return this.lsCommand(commandArgs[0]);
         break;
       case 'pwd':
-        this.pwdCommand();
+        return this.pwdCommand();
         break;
       case 'touch':
-        this.touchCommand(commandArgs);
+        return this.touchCommand(commandArgs);
         break;
       case 'mkdir':
-        this.mkdirCommand(commandArgs);
+        return this.mkdirCommand(commandArgs);
         break;
       case 'rm':
         //code
@@ -119,7 +118,7 @@ class App extends React.Component {
         break;
     }
 
-    this.setState({currentCommand: ''});
+    this.setState({currentCommand: []});
   }
 
   render() {

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -69,11 +69,9 @@ class App extends React.Component {
   lsCommand = (commandArg) => {
     if (!commandArg) {
       const directDescendants = Object.keys(this.findDirectDescendants())
-      directDescendants.forEach(descendant => {
-        console.log(descendant);
-      });
+      return directDescendants.join(' ');
     } else {
-      console.log("this command line doesn't have the capability to run `ls` with an argument!");
+      return 'this command line does not have the capability to run `ls` with an argument!';
     }
   }
 
@@ -86,7 +84,7 @@ class App extends React.Component {
   }
 
   pwdCommand = () => {
-    console.log(`root/${this.state.pathToCurrentLocation.join("/")}`);
+    return `root/${this.state.pathToCurrentLocation.join("/")}`;
   }
 
   handleNewCommand = (command) => {

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -37,10 +37,8 @@ class App extends React.Component {
 
       if (desiredPath.includes('..') || this.validRelationship(desiredPath[0])) {
         this.moveToValidDirectory(desiredPath);
-        //display previous command above command prompt
       } else {
         console.log(`cd: ${desiredPath[0]}: No such file or directory`);
-        //display previous command + output above command prompt
       }
     }
   }
@@ -91,12 +89,10 @@ class App extends React.Component {
     const commandType = command[0];
     const commandArgs = command.slice(1);
 
-    // LATER: anytime a command is run, we need to store that command + its output
-    //use state previousOutput
-
     switch (commandType) {
       case 'cd':
-        return this.cdCommand(commandArgs);
+        this.cdCommand(commandArgs);
+        return null;
         break;
       case 'ls':
         return this.lsCommand(commandArgs[0]);
@@ -105,16 +101,18 @@ class App extends React.Component {
         return this.pwdCommand();
         break;
       case 'touch':
-        return this.touchCommand(commandArgs);
+        this.touchCommand(commandArgs);
+        return null;
         break;
       case 'mkdir':
-        return this.mkdirCommand(commandArgs);
+        this.mkdirCommand(commandArgs);
+        return null;
         break;
       case 'rm':
         //code
         break;
       default:
-        console.log('you hit the default - this is not a command!');
+        return 'This is not a valid command!';
         break;
     }
 

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -31,7 +31,7 @@ class Terminal extends React.Component {
     return this.state.previousOutput.map(pair => {
       return (
         <div>
-          <p>{pair.command}</p>
+          <p>~ {pair.command}</p>
           <p>{pair.output}</p>
         </div>
       )

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -6,7 +6,8 @@ class Terminal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      command: ''
+      command: '',
+      previousOutput: []
     }
 
   }
@@ -17,16 +18,24 @@ class Terminal extends React.Component {
 
   submitCommand = (event) => {
     if (event.key === 'Enter') {
-      const splitCommand = this.state.command.split(' ');
-      this.props.handleNewCommand(splitCommand);
+      const command = this.state.command;
+      const splitCommand = command.split(' ');
+      const output = this.props.handleNewCommand(splitCommand);
+
+      this.state.previousOutput.push({command, output});
       this.setState({command: ''});
     }
   }
 
   showPreviousOutput = () => {
+    return this.state.previousOutput.map(pair => {
       return (
-        <p>is this working???</p>
+        <div>
+          <p>{pair.command}</p>
+          <p>{pair.output}</p>
+        </div>
       )
+    });
   }
 
   render() {


### PR DESCRIPTION
This PR:
- Makes a small refactor to the `cdCommand` method
- Reorganizes file structure so each component has a directory under `src/components` and a `jsx` file extension
- Single quotes in class, double quotes in JSX per airbnb 
- No spaces padding curly braces per airbnb 😢
- Adds default error message in switch statement. Need to keep breaks for each case, though

Update:
- Terminal holds `previousOutput` in state and renders previous commands and associated outputs above the command prompt
- Each command method has a return value (of output if it has one, or null if it doesn't have an output)