### PR TITLE
Feature/rm command

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -124,20 +124,26 @@ class App extends React.Component {
     const descendants = Object.keys(this.findDirectDescendants(this.state.pathToCurrentLocation));
     const path = [...this.state.pathToCurrentLocation];
 
-    return commandArgs.forEach(dir => {
+    let result = null;
+
+    commandArgs.forEach(dir => {
       path.push(dir);
       const pathToDelete = this.findDirectDescendants(path);
 
-      if (descendants.includes(dir) & Object.keys(pathToDelete).length === 0) {
-        delete this.findDirectDescendants(this.state.pathToCurrentLocation)[dir];
-        this.removeItemFromMapData(path);
-        //things break if a user runs this command on a file
+      if (descendants.includes(dir)) {
+        if (Object.keys(pathToDelete).length === 0) {
+          delete this.findDirectDescendants(this.state.pathToCurrentLocation)[dir];
+          this.removeItemFromMapData(path);
+        } else {
+          result = `rmdir: ${dir}: Directory not empty`;
+        }
       } else {
-        return "don't delete - send error message";
+        result = `rmdir: ${dir}: No such file or directory`;
       }
       path.pop();
     });
-    
+
+    return result;
   }
 
   removeItemFromMapData = (path) => {

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -116,12 +116,14 @@ class App extends React.Component {
   }
 
   rmCommand = (commandArgs) => {
-    // can pass multiple arguments
+    //similar to rmdir BUT don't need to check for empty contents
+    // need to verify its a file type
     console.log(commandArgs);
   }
 
   rmdirCommand = (commandArgs) => {
-    const descendants = Object.keys(this.findDirectDescendants(this.state.pathToCurrentLocation));
+    const descendants = this.findDirectDescendants(this.state.pathToCurrentLocation)
+    const descendantList = Object.keys(descendants);
     const path = [...this.state.pathToCurrentLocation];
 
     let result = null;
@@ -130,7 +132,12 @@ class App extends React.Component {
       path.push(dir);
       const pathToDelete = this.findDirectDescendants(path);
 
-      if (descendants.includes(dir)) {
+      if (typeof descendants[dir] !== "object") {
+        result = `rmdir: ${dir}: Not a directory`
+        return;
+      }
+
+      if (descendantList.includes(dir)) {
         if (Object.keys(pathToDelete).length === 0) {
           delete this.findDirectDescendants(this.state.pathToCurrentLocation)[dir];
           this.removeItemFromMapData(path);


### PR DESCRIPTION
This PR:
- creates functionality to handle the `rm` and `rmdir` commands

Since there is a lot of shared functionality, both commands call a "removeCommand" intermediary which does the set up, check the specific command run, then calls a `rm` or `rmdir` specific method that handles the checks unique to it.

TO DO/think about: This does not yet cover the `-rf` flag; `rm` only removes files and `rmdir` only removes empty directories. Considering - do we want to teach Mod 0 students to use `rm -rf`?? If so, this can be built in after we get an MVP.