### PR TITLE
Feature/cycle commands

### DIFF
--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -53,15 +53,16 @@ class Terminal extends React.Component {
   }
 
   cycleCommands = (event) => {
+    const indexToCheck = this.state.index === null ? this.state.previousOutput.length : this.state.index;
+
     if (event.key === "ArrowUp") {
-      this.showPreviousCommand();
+      this.showPreviousCommand(indexToCheck);
     } else if (event.key === "ArrowDown") {
-      this.showNextCommand();
+      this.showNextCommand(indexToCheck);
     }
   }
 
-  showPreviousCommand = () => {
-    const indexToCheck = this.state.index === null ? this.state.previousOutput.length : this.state.index;
+  showPreviousCommand = (indexToCheck) => {
     if (this.state.previousOutput[indexToCheck - 1]) {
       this.setState({
         index: indexToCheck - 1,
@@ -73,8 +74,18 @@ class Terminal extends React.Component {
   }
 
 
-  showNextCommand = () => {
-
+  showNextCommand = (indexToCheck) => {
+    if (this.state.previousOutput[indexToCheck + 1]) {
+      this.setState({
+        index: indexToCheck + 1,
+        command: this.state.previousOutput[indexToCheck + 1].command
+      });
+    } else {
+      this.setState({
+        index: null,
+        command: ''
+      });
+    }
   }
 
   render() {

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -41,14 +41,16 @@ class Terminal extends React.Component {
 
   showPreviousOutput = () => {
     return this.state.previousOutput.map((pair, index) => {
-      return (
-        <div key={index}>
+      if (pair.command) {
+        return (
+          <div key={index}>
           <p className="mono">~
-            <span className="output">{pair.command}</span>
+          <span className="output">{pair.command}</span>
           </p>
           <p className="mono">{pair.output}</p>
-        </div>
-      )
+          </div>
+        )
+      }
     });
   }
 
@@ -72,7 +74,6 @@ class Terminal extends React.Component {
       this.setState({index: null});
     }
   }
-
 
   showNextCommand = (indexToCheck) => {
     if (this.state.previousOutput[indexToCheck + 1]) {

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -6,8 +6,9 @@ class Terminal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      index: null,
       command: '',
-      previousOutput: []
+      previousOutput: [{command: '', output: ''}]
     }
   }
 
@@ -51,6 +52,31 @@ class Terminal extends React.Component {
     });
   }
 
+  cycleCommands = (event) => {
+    if (event.key === "ArrowUp") {
+      this.showPreviousCommand();
+    } else if (event.key === "ArrowDown") {
+      this.showNextCommand();
+    }
+  }
+
+  showPreviousCommand = () => {
+    const indexToCheck = this.state.index === null ? this.state.previousOutput.length : this.state.index;
+    if (this.state.previousOutput[indexToCheck - 1]) {
+      this.setState({
+        index: indexToCheck - 1,
+        command: this.state.previousOutput[indexToCheck - 1].command
+      });
+    } else {
+      this.setState({index: null});
+    }
+  }
+
+
+  showNextCommand = () => {
+
+  }
+
   render() {
     return (
       <div className="terminal-window">
@@ -68,6 +94,7 @@ class Terminal extends React.Component {
           value={this.state.command}
           onChange={this.handleInput}
           onKeyPress={this.submitCommand}
+          onKeyDown={this.cycleCommands}
         />
       </div>
     );

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -44,10 +44,10 @@ class Terminal extends React.Component {
       if (pair.command) {
         return (
           <div key={index}>
-          <p className="mono">~
-          <span className="output">{pair.command}</span>
-          </p>
-          <p className="mono">{pair.output}</p>
+            <p className="mono">~
+            <span className="output">{pair.command}</span>
+            </p>
+            <p className="mono">{pair.output}</p>
           </div>
         )
       }
@@ -68,7 +68,7 @@ class Terminal extends React.Component {
     if (this.state.previousOutput[indexToCheck - 1]) {
       this.setState({
         index: indexToCheck - 1,
-        command: this.state.previousOutput[indexToCheck - 1].command
+        command: this.state.previousOutput[indexToCheck - 1].command,
       });
     } else {
       this.setState({index: null});
@@ -79,12 +79,12 @@ class Terminal extends React.Component {
     if (this.state.previousOutput[indexToCheck + 1]) {
       this.setState({
         index: indexToCheck + 1,
-        command: this.state.previousOutput[indexToCheck + 1].command
+        command: this.state.previousOutput[indexToCheck + 1].command,
       });
     } else {
       this.setState({
         index: null,
-        command: ''
+        command: '',
       });
     }
   }


### PR DESCRIPTION
This PR:
- adds functionality so user can use up and down arrows to cycle through previously run commands.
- adds a new piece of state in Terminal - `index` (not a huge fan of the naming but that's what I came up with atm). This is a Number that keeps track of which command in the `previousOutput` array is being displayed, making for a relatively easy look up and more reliable - since the `command` in state is just a string and may likely exist as a command property in more than one `previousOutput` object.

It feels ridiculous to have `onChange`, `onKeyDown` and `onKeyPress` but from my research, `onKeyDown/Up` were the only listeners that could play with the arrow buttons, same for `onKeyPress` and enter/return. Maybe look into more later.