### PR TITLE
Feature/command card collapse

### DIFF
--- a/src/components/CommandCard/CommandCard.scss
+++ b/src/components/CommandCard/CommandCard.scss
@@ -23,11 +23,14 @@
 
 .command-card-content {
   padding: 5px 30px 10px;
+  // animation: expand 7s ease;
 }
 
 .hide {
   display: none;
+  // animation: collapse 2s infinite;
 }
+
 .command-card-example {
   background-color: #20232a;
   color: #fff;

--- a/src/components/CommandCard/CommandCard.scss
+++ b/src/components/CommandCard/CommandCard.scss
@@ -1,7 +1,7 @@
 .command-card {
   border: 1px solid black;
   border-radius: 3px;
-  padding: 10px 30px;
+  // padding: 10px 30px;
   margin-bottom: 10px;
 
   h2 {
@@ -13,12 +13,21 @@
 .command-card-header {
   display: flex;
   justify-content: space-between;
+  cursor: pointer;
+  padding: 10px 30px 10px;
+}
+
+.command-card-header:hover {
+  background-color: #F1F1F1;
 }
 
 .command-card-content {
-  // display: none;
+  padding: 5px 30px 10px;
 }
 
+.hide {
+  display: none;
+}
 .command-card-example {
   background-color: #20232a;
   color: #fff;

--- a/src/components/CommandCard/index.jsx
+++ b/src/components/CommandCard/index.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import './CommandCard.scss';
 
-const CommandCard = ({command}) => {
+class CommandCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+    }
+  }
 
-  const displayCommandSnippets = (code) => {
+  displayCommandSnippets = (code) => {
     return code.map(code => {
       if (code.command) {
         return <p className="how-code">$ {code.command}</p>
@@ -13,38 +19,50 @@ const CommandCard = ({command}) => {
     });
   }
 
-  const displayExplanations = (explanations) => {
+  displayExplanations = (explanations) => {
     return explanations.map(part => {
       if (part.text) {
         return <p className="how-text">{part.text}</p>
       } else {
         return (
           <div className="command-card-example">
-            {displayCommandSnippets(part.code)}
-            <p className="how-code">$ </p>
+          {this.displayCommandSnippets(part.code)}
+          <p className="how-code">$ </p>
           </div>
         );
       }
     });
   }
 
-  return (
-    <section className="command-card">
-      <div className="command-card-header">
-        <h2>{command.commandName}</h2>
-        <h2>^</h2>
-      </div>
-      <div className="command-card-content">
-        <h3>Why would I use this command?</h3>
-        <p>{command.why1}</p>
-        <p>{command.why2}</p>
-        <h3>How do I use this command?</h3>
-        <div>{displayExplanations(command.how)}</div>
-        <h3>What are the common mistakes made with this command?</h3>
-        <p>{displayExplanations(command.mistakes)}</p>
-      </div>
-    </section>
-  );
+  toggleExpand = () => {
+    this.setState({isExpanded: !this.state.isExpanded});
+  }
+
+  render() {
+    const {command} = this.props;
+
+    return (
+      <section className="command-card">
+        <div
+          className="command-card-header"
+          onClick={this.toggleExpand}
+        >
+          <h2>{command.commandName}</h2>
+          <h2>^</h2>
+        </div>
+        <div className={this.state.isExpanded ? "command-card-content" : "hide"}>
+          <h3>Why would I use this command?</h3>
+          <p>{command.why1}</p>
+          <p>{command.why2}</p>
+          <h3>How do I use this command?</h3>
+          <div>{this.displayExplanations(command.how)}</div>
+          <h3>What are the common mistakes made with this command?</h3>
+          <div>{this.displayExplanations(command.mistakes)}</div>
+        </div>
+      </section>
+    );
+  }
 }
+
 
 export default CommandCard;

--- a/src/components/CommandCard/index.jsx
+++ b/src/components/CommandCard/index.jsx
@@ -1,15 +1,10 @@
-import React from 'react';
+import React, {useState} from 'react';
 import './CommandCard.scss';
 
-class CommandCard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isExpanded: false,
-    }
-  }
+const CommandCard = ({command}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  displayCommandSnippets = (code) => {
+  const displayCommandSnippets = (code) => {
     return code.map(code => {
       if (code.command) {
         return <p className="how-code">$ {code.command}</p>
@@ -19,14 +14,14 @@ class CommandCard extends React.Component {
     });
   }
 
-  displayExplanations = (explanations) => {
+  const displayExplanations = (explanations) => {
     return explanations.map(part => {
       if (part.text) {
         return <p className="how-text">{part.text}</p>
       } else {
         return (
           <div className="command-card-example">
-          {this.displayCommandSnippets(part.code)}
+          {displayCommandSnippets(part.code)}
           <p className="how-code">$ </p>
           </div>
         );
@@ -34,35 +29,96 @@ class CommandCard extends React.Component {
     });
   }
 
-  toggleExpand = () => {
-    this.setState({isExpanded: !this.state.isExpanded});
+  const toggleExpand = () => {
+    setIsExpanded(!isExpanded);
   }
 
-  render() {
-    const {command} = this.props;
-
-    return (
-      <section className="command-card">
-        <div
-          className="command-card-header"
-          onClick={this.toggleExpand}
-        >
-          <h2>{command.commandName}</h2>
-          <h2>^</h2>
-        </div>
-        <div className={this.state.isExpanded ? "command-card-content" : "hide"}>
-          <h3>Why would I use this command?</h3>
-          <p>{command.why1}</p>
-          <p>{command.why2}</p>
-          <h3>How do I use this command?</h3>
-          <div>{this.displayExplanations(command.how)}</div>
-          <h3>What are the common mistakes made with this command?</h3>
-          <div>{this.displayExplanations(command.mistakes)}</div>
-        </div>
-      </section>
-    );
-  }
+  return (
+    <section className="command-card">
+      <div
+        className="command-card-header"
+        onClick={toggleExpand}
+      >
+        <h2>{command.commandName}</h2>
+        <h2>^</h2>
+      </div>
+      <div className={isExpanded ? "command-card-content" : "hide"}>
+        <h3>Why would I use this command?</h3>
+        <p>{command.why1}</p>
+        <p>{command.why2}</p>
+        <h3>How do I use this command?</h3>
+        <div>{displayExplanations(command.how)}</div>
+        <h3>What are the common mistakes made with this command?</h3>
+        <div>{displayExplanations(command.mistakes)}</div>
+      </div>
+    </section>
+  )
 }
+//
+// class CommandCard extends React.Component {
+//   constructor(props) {
+//     super(props);
+//     this.state = {
+//       isExpanded: false,
+//     }
+//   }
+//
+//   displayCommandSnippets = (code) => {
+//     return code.map(code => {
+//       if (code.command) {
+//         return <p className="how-code">$ {code.command}</p>
+//       } else {
+//         return <p className="how-code">{code.output}</p>
+//       }
+//     });
+//   }
+//
+//   displayExplanations = (explanations) => {
+//     return explanations.map(part => {
+//       if (part.text) {
+//         return <p className="how-text">{part.text}</p>
+//       } else {
+//         return (
+//           <div className="command-card-example">
+//           {this.displayCommandSnippets(part.code)}
+//           <p className="how-code">$ </p>
+//           </div>
+//         );
+//       }
+//     });
+//   }
+//
+//   toggleExpand = () => {
+//     this.setState(({isExpanded}) => {
+//       return {isExpanded: !isExpanded}
+//     });
+//   }
+//
+//   render() {
+//     const {command} = this.props;
+//
+//     return (
+//       <section className="command-card">
+//         <div
+//           className="command-card-header"
+//           onClick={this.toggleExpand}
+//         >
+//           <h2>{command.commandName}</h2>
+//           <h2>^</h2>
+//         </div>
+//         <div className={this.state.isExpanded ? "command-card-content" : "hide"}>
+//           <h3>Why would I use this command?</h3>
+//           <p>{command.why1}</p>
+//           <p>{command.why2}</p>
+//           <h3>How do I use this command?</h3>
+//           <div>{this.displayExplanations(command.how)}</div>
+//           <h3>What are the common mistakes made with this command?</h3>
+//           <div>{this.displayExplanations(command.mistakes)}</div>
+//         </div>
+//       </section>
+//     );
+//   }
+// }
 
 
 export default CommandCard;

--- a/src/components/CommandCard/index.jsx
+++ b/src/components/CommandCard/index.jsx
@@ -21,8 +21,8 @@ const CommandCard = ({command}) => {
       } else {
         return (
           <div className="command-card-example">
-          {displayCommandSnippets(part.code)}
-          <p className="how-code">$ </p>
+            {displayCommandSnippets(part.code)}
+            <p className="how-code">$ </p>
           </div>
         );
       }
@@ -52,73 +52,7 @@ const CommandCard = ({command}) => {
         <div>{displayExplanations(command.mistakes)}</div>
       </div>
     </section>
-  )
+  );
 }
-//
-// class CommandCard extends React.Component {
-//   constructor(props) {
-//     super(props);
-//     this.state = {
-//       isExpanded: false,
-//     }
-//   }
-//
-//   displayCommandSnippets = (code) => {
-//     return code.map(code => {
-//       if (code.command) {
-//         return <p className="how-code">$ {code.command}</p>
-//       } else {
-//         return <p className="how-code">{code.output}</p>
-//       }
-//     });
-//   }
-//
-//   displayExplanations = (explanations) => {
-//     return explanations.map(part => {
-//       if (part.text) {
-//         return <p className="how-text">{part.text}</p>
-//       } else {
-//         return (
-//           <div className="command-card-example">
-//           {this.displayCommandSnippets(part.code)}
-//           <p className="how-code">$ </p>
-//           </div>
-//         );
-//       }
-//     });
-//   }
-//
-//   toggleExpand = () => {
-//     this.setState(({isExpanded}) => {
-//       return {isExpanded: !isExpanded}
-//     });
-//   }
-//
-//   render() {
-//     const {command} = this.props;
-//
-//     return (
-//       <section className="command-card">
-//         <div
-//           className="command-card-header"
-//           onClick={this.toggleExpand}
-//         >
-//           <h2>{command.commandName}</h2>
-//           <h2>^</h2>
-//         </div>
-//         <div className={this.state.isExpanded ? "command-card-content" : "hide"}>
-//           <h3>Why would I use this command?</h3>
-//           <p>{command.why1}</p>
-//           <p>{command.why2}</p>
-//           <h3>How do I use this command?</h3>
-//           <div>{this.displayExplanations(command.how)}</div>
-//           <h3>What are the common mistakes made with this command?</h3>
-//           <div>{this.displayExplanations(command.mistakes)}</div>
-//         </div>
-//       </section>
-//     );
-//   }
-// }
-
 
 export default CommandCard;

--- a/src/components/Learn/index.jsx
+++ b/src/components/Learn/index.jsx
@@ -19,6 +19,18 @@ const Learn = () => {
   return (
     <main className="learn-main">
       <h1>Learn</h1>
+      <h2>What is the Command Line?</h2>
+      <p>A <strong>command line</strong> is a low-level interface to your computer. Instead of pointing and clicking on things in the finder, we can type text into a command line to interact with the contents of your computer.</p>
+      <h2>What is the Terminal and why do we need it?</h2>
+      <p>A <strong>terminal</strong> is a program on your computer that lets you interact with the command line - it’s the application you’ll actually type commands into! On your mac, you might use the Terminal or iTerm applications. In this tutorial, we will use a small version of those applications that is built into this site.</p>
+      <p>The terminal allows developers to navigate the directories on their computer quickly. When you start off, it may feel like clicking around in the finder is faster than remembering which command to use when, etc. But once you learn and practice them, you’ll notice how much your time is maximized! Additionally, some of the tools you will use as a developer can only be accessed through the terminal.</p>
+      <h2>Vocabulary</h2>
+      <p>Before you start learning about some must-know commands in the section below, you may want to familiarize yourself with the following vocabulary:</p>
+      <ul>
+        <li><strong>Command Prompt:</strong> Your terminal will indicate that it’s ready to be given a command when the prompt appears on the left of the window. It is usually a $ sign. When copying and pasting commands from the internet, do not include the $. It is meant to symbolize that a command is run from the terminal.</li>
+        <li><strong>Running a command:</strong> Throughout this page and other resources online, you’ll hear folks use the phrase “run the command”. What we mean when we say that is, type the command into the terminal, and then hit return.</li>
+        <li><strong>Directory:</strong> Developers, and most documentation you read regarding coding, will refer to folders on a computer as directories.</li>
+      </ul>
       {displayCommandCards()}
     </main>
   );


### PR DESCRIPTION
This PR:
- Allows a user to click on the header of a command card to toggle viewing the content of the entire card
- Implements the `useState` hook in the CommandCard component