### PR TITLE
Feature/recent command

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -267,7 +267,7 @@ class App extends React.Component {
         return this.removeCommands(commandArgs, 'rmdir');
         break;
       default:
-        this.setState({currentCommand: 'You just ran a command that does not exist'});
+        this.setState({currentCommand: 'Oops!'});
         return `${commandType}: command not found`;
     }
 

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -24,7 +24,7 @@ class App extends React.Component {
       currentLevel: 0,
       pathToCurrentLocation: [],
       currentCommand: [],
-      currentExplanation: '',
+      currentCommand: '',
       mapData: [
         {title: "root", type: "dir", levelFromRoot: 0, current: true},
         {title: "turing", type: "dir", levelFromRoot: 1, current: false},
@@ -238,17 +238,7 @@ class App extends React.Component {
     const commandType = command[0];
     const commandArgs = command.slice(1);
 
-    const explanations = {
-      'cd': 'You just ran cd.',
-      'ls': 'You just ran ls.',
-      'pwd': 'You just ran pwd.',
-      'touch': 'You just ran touch.',
-      'mkdir': 'You just ran mkdir.',
-      'rm': 'You just ran rm',
-      'rmdir': 'You just ran rmdir',
-     }
-
-    this.setState({currentExplanation: explanations[commandType]});
+    this.setState({currentCommand: commandType});
 
     switch (commandType) {
       case 'cd':
@@ -277,7 +267,7 @@ class App extends React.Component {
         return this.removeCommands(commandArgs, 'rmdir');
         break;
       default:
-        this.setState({currentExplanation: 'You just ran a command that does not exist'});
+        this.setState({currentCommand: 'You just ran a command that does not exist'});
         return `${commandType}: command not found`;
     }
 
@@ -305,7 +295,7 @@ class App extends React.Component {
               <Practice
                 handleNewCommand={this.handleNewCommand}
                 mapData={mapData}
-                currentExplanation={this.state.currentExplanation}
+                currentCommand={this.state.currentCommand}
                 directoryStructure={this.state.directoryStructure}
                 currentPath={this.state.pathToCurrentLocation}
                 />

--- a/src/components/Map/Map.scss
+++ b/src/components/Map/Map.scss
@@ -1,5 +1,5 @@
 .map-container {
-  width: 37%;
+  width: 45%;
 }
 
 .visualizations {

--- a/src/components/Map/Map.scss
+++ b/src/components/Map/Map.scss
@@ -1,5 +1,6 @@
 .map-container {
   width: 45%;
+  border: 1px solid red;
 }
 
 .visualizations {

--- a/src/components/Map/Map.scss
+++ b/src/components/Map/Map.scss
@@ -1,6 +1,5 @@
 .map-container {
   width: 45%;
-  border: 1px solid red;
 }
 
 .visualizations {

--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import './Map.scss';
 import Visualization from '../Visualization';
+import RecentCommandCard from '../RecentCommandCard';
 
-const Map = ({currentExplanation, mapData, currentPath}) => {
+const Map = ({currentCommand, mapData, currentPath}) => {
 
   const displayMapData = () => {
     return mapData.map((item, index) => {
@@ -23,7 +24,7 @@ const Map = ({currentExplanation, mapData, currentPath}) => {
 
   return (
     <section className="map-container">
-      <p>{currentExplanation}</p>
+      <RecentCommandCard currentCommand={currentCommand}/>
       <div className="visualizations">
         {displayMapData()}
       </div>

--- a/src/components/Map/index.jsx
+++ b/src/components/Map/index.jsx
@@ -3,7 +3,7 @@ import './Map.scss';
 import Visualization from '../Visualization';
 import RecentCommandCard from '../RecentCommandCard';
 
-const Map = ({currentCommand, mapData, currentPath}) => {
+const Map = ({mapData, currentPath}) => {
 
   const displayMapData = () => {
     return mapData.map((item, index) => {
@@ -24,7 +24,7 @@ const Map = ({currentCommand, mapData, currentPath}) => {
 
   return (
     <section className="map-container">
-      <RecentCommandCard currentCommand={currentCommand}/>
+
       <div className="visualizations">
         {displayMapData()}
       </div>

--- a/src/components/Practice/Practice.scss
+++ b/src/components/Practice/Practice.scss
@@ -48,11 +48,12 @@
   border: 2px solid #FFA2FF;
   cursor: pointer;
   border-radius: 3px;
+  transition: 1s ease;
+  align-items: center;
 }
 
 .start-btn {
   font-size: 120%;
-  align-items: center;
   padding: 0.5em;
   width: 35%;
   margin: 0 auto;
@@ -68,7 +69,6 @@
   padding: 0.5em 1em;
   font-size: 90%;
   display: flex;
-  align-items: center;
 }
 
 .practice-started {
@@ -83,6 +83,7 @@
 .start-btn:hover,
 .show-directions-btn:hover {
   background-color: #FFE1FF;
+  transition: 1s ease;
 }
 
 .right-arrow {

--- a/src/components/Practice/index.jsx
+++ b/src/components/Practice/index.jsx
@@ -5,7 +5,7 @@ import arrow from './assets/arrow.svg';
 
 import './Practice.scss';
 
-const Practice = ({handleNewCommand, mapData, currentExplanation, directoryStructure, currentPath}) => {
+const Practice = ({handleNewCommand, mapData, currentCommand, directoryStructure, currentPath}) => {
   let isReturning;
   if (localStorage.getItem('isReturning') === 'true') {
     isReturning = true;
@@ -41,9 +41,9 @@ const Practice = ({handleNewCommand, mapData, currentExplanation, directoryStruc
         <div className="terminal-map-container">
           <Terminal handleNewCommand={handleNewCommand}/>
           <Map
-          mapData={mapData}
-          currentExplanation={currentExplanation}
-          directoryStructure={directoryStructure}
+            mapData={mapData}
+            currentCommand={currentCommand}
+            directoryStructure={directoryStructure}
           />
         </div>
         <button className="show-directions-btn" onClick={changeVisitorStatus}>

--- a/src/components/Practice/index.jsx
+++ b/src/components/Practice/index.jsx
@@ -39,10 +39,12 @@ const Practice = ({handleNewCommand, mapData, currentCommand, directoryStructure
     return (
       <div className="practice-started">
         <div className="terminal-map-container">
-          <Terminal handleNewCommand={handleNewCommand}/>
+          <Terminal
+            handleNewCommand={handleNewCommand}
+            currentCommand={currentCommand}
+          />
           <Map
             mapData={mapData}
-            currentCommand={currentCommand}
             directoryStructure={directoryStructure}
           />
         </div>

--- a/src/components/RecentCommandCard/RecentCommandCard.scss
+++ b/src/components/RecentCommandCard/RecentCommandCard.scss
@@ -1,0 +1,22 @@
+.recent-command-card {
+  border: 1px solid #FFA2FF;
+  border-radius: 3px;
+  margin-bottom: 10px;
+  color: #20232a;
+  background-color: #FFFBFF;
+  padding: 1em;
+
+  h4 {
+    font-size: 130%;
+    font-family: 'Anonymous Pro', monospace;
+    margin: 0;
+  }
+}
+
+.show-details {
+  display: block;
+}
+
+.hide-details {
+  display: none;
+}

--- a/src/components/RecentCommandCard/RecentCommandCard.scss
+++ b/src/components/RecentCommandCard/RecentCommandCard.scss
@@ -5,6 +5,10 @@
   color: #20232a;
   background-color: #FFFBFF;
   padding: 1em;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 25%;
 
   h4 {
     font-size: 130%;

--- a/src/components/RecentCommandCard/RecentCommandCard.scss
+++ b/src/components/RecentCommandCard/RecentCommandCard.scss
@@ -14,7 +14,13 @@
     font-size: 130%;
     font-family: 'Anonymous Pro', monospace;
     margin: 0;
+    cursor: pointer;
   }
+}
+
+.recent-command-card:hover {
+  background-color: #FFE1FF;
+  transition: 1s ease;
 }
 
 .show-details {

--- a/src/components/RecentCommandCard/index.jsx
+++ b/src/components/RecentCommandCard/index.jsx
@@ -1,0 +1,24 @@
+import React, {useState} from 'react';
+import './RecentCommandCard.scss';
+
+const RecentCommandCard = ({currentCommand}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const toggleExpand = () => {
+    setIsExpanded(!isExpanded);
+  }
+
+  return (
+    <section className="recent-command-card">
+      <h4 onClick={toggleExpand}>{currentCommand || "No command yet..."}</h4>
+      <div className={isExpanded ? "show-details" : "hide-details"}>
+        <p>details</p>
+        <p>details</p>
+        <p>details</p>
+      </div>
+    </section>
+  );
+
+}
+
+export default RecentCommandCard;

--- a/src/components/RecentCommandCard/index.jsx
+++ b/src/components/RecentCommandCard/index.jsx
@@ -10,7 +10,7 @@ const RecentCommandCard = ({currentCommand}) => {
 
   return (
     <section className="recent-command-card">
-      <h4 onClick={toggleExpand}>{currentCommand || "No command yet..."}</h4>
+      <h4 onClick={toggleExpand}>{currentCommand || "Run a command!"}</h4>
       <div className={isExpanded ? "show-details" : "hide-details"}>
         <p>details</p>
         <p>details</p>

--- a/src/components/Terminal/Terminal.scss
+++ b/src/components/Terminal/Terminal.scss
@@ -8,6 +8,7 @@
   overflow-y: scroll;
   margin-right: 2em;
   margin-bottom: 14em;
+  position: relative;
 }
 
 .mono {

--- a/src/components/Terminal/Terminal.scss
+++ b/src/components/Terminal/Terminal.scss
@@ -1,7 +1,7 @@
 .terminal-window {
   background-color: #27292E;
   color: #fff;
-  width: 58%;
+  width: 50%;
   border-radius: 3px;
   padding: 1em;
   height: 22em;

--- a/src/components/Terminal/index.jsx
+++ b/src/components/Terminal/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Terminal.scss';
+import RecentCommandCard from '../RecentCommandCard';
 
 class Terminal extends React.Component {
 
@@ -32,9 +33,9 @@ class Terminal extends React.Component {
   }
 
   showWelcomeMessage = () => {
-    return (
-      <p className="mono welcome">Welcome! Type in any command...</p>
-    );
+    // return (
+      // <p className="mono welcome">Welcome! Type in any command...</p>
+    // );
   }
 
   showPreviousOutput = () => {
@@ -107,6 +108,7 @@ class Terminal extends React.Component {
           onKeyDown={this.cycleCommands}
           autcomplete="off"
         />
+        <RecentCommandCard currentCommand={this.props.currentCommand}/>
       </div>
     );
   }


### PR DESCRIPTION
This PR:
- Adds a recent command card in the top-right corner of the Terminal
- Card can currently collapse and expand, on collapse shows the name of the command the user most recently run. Does not yet have relevant content in expand mode.

I think I hate it
- It's a little distracting from the Map
- I don't know WHERE this little box should live?

![image](https://user-images.githubusercontent.com/25447342/80867512-ba0ee780-8c51-11ea-99d5-072f911a9b46.png)